### PR TITLE
addons: Include turbo_adapter sepolicy

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -53,6 +53,9 @@ BOARD_SEPOLICY_DIRS += \
     hardware/google/pixel-sepolicy/flipendo
 endif
 
+BOARD_SEPOLICY_DIRS += \
+   hardware/google/pixel-sepolicy/turbo_adapter
+
 # Fonts
 PRODUCT_PACKAGES += \
     fonts_customization.xml \


### PR DESCRIPTION
* Since we are shipping prebuilt Turbo adapter.

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>

Somehow this got lost during the constant rebasing (smh)