### PR TITLE
Add & update some camera package mappings

### DIFF
--- a/overlay/common/packages/apps/Launcher3/res/xml/grayscale_icon_map.xml
+++ b/overlay/common/packages/apps/Launcher3/res/xml/grayscale_icon_map.xml
@@ -1249,7 +1249,6 @@
     <icon drawable="@drawable/camera" package="com.motorola.cameraone" />
     <icon drawable="@drawable/camera" package="com.motorola.odm.camera3" />
     <icon drawable="@drawable/camera" package="com.ngcam.camera" />
-    <icon drawable="@drawable/camera" package="com.oneplus.camera" />
     <icon drawable="@drawable/camera" package="com.ontim.camera2" />
     <icon drawable="@drawable/camera" package="com.oplus.camera" />
     <icon drawable="@drawable/camera" package="com.oppo.camera" />
@@ -2668,7 +2667,6 @@
     <icon drawable="@drawable/gallery" package="com.huawei.photos" />
     <icon drawable="@drawable/gallery" package="com.miui.gallery" />
     <icon drawable="@drawable/gallery" package="com.motorola.cn.gallery" />
-    <icon drawable="@drawable/gallery" package="com.oneplus.gallery" />
     <icon drawable="@drawable/gallery" package="com.oplus.gallery" />
     <icon drawable="@drawable/gallery" package="com.oppo.gallery3d" />
     <icon drawable="@drawable/gallery" package="com.sec.android.gallery3d" />
@@ -5517,6 +5515,7 @@
     <icon drawable="@drawable/pixelfed" package="com.pixelfed" />
     <icon drawable="@drawable/pixelful_icons" package="com.ciaostudio.pixeliconpack" />
     <icon drawable="@drawable/pixelify_gphotos" package="balti.xposed.pixelifygooglephotos" />
+    <icon drawable="@drawable/pixelify_gphotos" package="com.oneplus.gallery" />
     <icon drawable="@drawable/pixellab" package="com.imaginstudio.imagetools.pixellab" />
     <icon drawable="@drawable/pixels" package="com.tribalfs.pixels" />
     <icon drawable="@drawable/pixels_icons" package="com.jndapp.pixel.pie.iconpack" />
@@ -7219,6 +7218,7 @@
     <icon drawable="@drawable/timeplanner" package="ru.aleshin.timeplanner" />
     <icon drawable="@drawable/times_of_india" package="com.toi.reader.activities" />
     <icon drawable="@drawable/timestamp_camera" package="com.jeyluta.timestampcamerafree" />
+    <icon drawable="@drawable/timestamp_camera" package="com.oneplus.camera" />
     <icon drawable="@drawable/timetable" package="com.gabrielittner.timetable" />
     <icon drawable="@drawable/timetree" package="works.jubilee.timetree" />
     <icon drawable="@drawable/timezone_fun" package="com.teegloyalty.timezone" />

--- a/overlay/common/packages/apps/Launcher3/res/xml/grayscale_icon_map.xml
+++ b/overlay/common/packages/apps/Launcher3/res/xml/grayscale_icon_map.xml
@@ -4988,6 +4988,7 @@
     <icon drawable="@drawable/nothing_adaptive_blue_icons" package="dev.narikdesign.nothingblue" />
     <icon drawable="@drawable/nothing_adaptive_icons" package="dev.narikdesign.nothingadaptive" />
     <icon drawable="@drawable/nothing_camera" package="com.nothing.camera" />
+    <icon drawable="@drawable/nothing_camera" package="org.codeaurora.mjlxcam" />
     <icon drawable="@drawable/nothing_gallery" package="com.nothing.gallery" />
     <icon drawable="@drawable/nothing_icons" package="com.nothing.icon.free" />
     <icon drawable="@drawable/nothing_icons" package="com.nothing.icon.pro" />
@@ -7584,6 +7585,7 @@
     <icon drawable="@drawable/vector" package="com.nekki.vector" />
     <icon drawable="@drawable/vector_asset_creator" package="com.inglesdivino.vectorassetcreator" />
     <icon drawable="@drawable/vector_camera" package="com.dozingcatsoftware.vectorcamera" />
+    <icon drawable="@drawable/vector_camera" package="org.codeaurora.quettre" />
     <icon drawable="@drawable/vectorify_da_home" package="com.iven.iconify" />
     <icon drawable="@drawable/vectras_vm" package="com.vectras.vm" />
     <icon drawable="@drawable/velobank" package="com.getingroup.mobilebanking" />


### PR DESCRIPTION
MJL GCam ports:
- I tried to find camera-related icons "close enough" to the originals, since the people installing these typically have multiple camera apps and benefit from a way to easily tell them apart (especially since we can't relabel icons in launcher yet).

OnePlusCamera/Gallery:
- Camera: Again, picking something to make it easier to tell multiple camera apps apart but still resembles the original... in this case, the OOS 11 icon we had on OP6-series had the vertical stripes above/below the lens, and this seemed the most evocative. Doesn't impact mapping for com.oplus.camera (which is what you all seem to have now).
- Gallery: I realize com.oneplus.gallery is still being used in 15.0, if anyone includes that repository. I tried to pick an obviously "gallery" icon so it doesn't change dramatically, but still not identical to Glimpse/Gallery2. Again, the goal is to make it easier to tell *which* gallery app you're opening (since opcam has dependency on gallery). But I realize others should have a say here as well.